### PR TITLE
Fix small bug in javascript.vim

### DIFF
--- a/indent/javascript.vim
+++ b/indent/javascript.vim
@@ -86,7 +86,7 @@ function! s:SearchForPair(lnum, beg, end)
 
 	" Set the cursor position to the beginning of the line (default
 	" behavior when using ==)
-	call cursor(a:lnum, 0)
+	call cursor(a:lnum, 1)
 
 	" Search for the opening tag
 	let mnum = searchpair(a:beg, '', a:end, 'bW', 


### PR DESCRIPTION
Sometimes javascript.vim produce invalid indention with enabled indentkeys options
